### PR TITLE
Increase margin-top for .wrapper to create larger space between setti…

### DIFF
--- a/style.css
+++ b/style.css
@@ -30,7 +30,7 @@ body {
   background: #f8f8f8;
   border-radius: 10px;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-  margin-top: 20px; /* Add margin-top to create space between settings and game card box */
+  margin-top: 50px; /* Increase margin-top to create a larger space between settings and game card box */
 }
 
 .cards,


### PR DESCRIPTION
# Pull Request: Increase Margin-Top for .wrapper to Create Larger Space Between Settings and Game Card Box

## Summary
This pull request includes a change to the CSS file to increase the `margin-top` value for the `.wrapper` class. This adjustment creates a larger space between the settings box and the game card box, improving the overall layout and user experience.

## Changes
### style.css
- Increased the `margin-top` value of the `.wrapper` class from 20px to 50px to create a larger space between the settings and game card box.

## Motivation
The change was made to enhance the visual separation between the settings section and the game card section, making the layout more aesthetically pleasing and easier to navigate.

## Related Issues
- N/A

## Testing
- Verified that the increased margin-top value effectively creates a larger space between the settings and game card box.
- Ensured that the layout remains responsive and visually appealing on different screen sizes.

## Additional Notes
- Please review the changes and provide feedback if any further adjustments are needed.